### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+language: bash
+sudo: true
+
+branches:
+ - master
+ - travis
+
+install:
+ - sudo apt-get install autoconf
+ - sudo apt-get install automake
+ - sudo apt-get install libtool
+ - sudo apt-get install m4
+ - sudo apt-get install wget
+ - sudo apt-get install gzip
+ - sudo apt-get install bzip2
+ - sudo apt-get install bison
+ - sudo apt-get install g++
+
+matrix:
+  include:
+    - stage: normal
+      script:
+        - ./compile.sh -t linux64 -c -f -g -j 32 -l -u
+        - ./testbin.sh
+    - stage: debug
+      script:
+        - ./compile.sh -t linux64 -c -d -f -g -j 32 -l -u
+        - ./testbin.sh
+    - stage: normal-static
+      script:
+        - ./compile.sh -t linux64 -c -f -g -j 32 -l -u -s
+        - ./testbin.sh
+    - stage: debug-static
+      script:
+        - ./compile.sh -t linux64 -c -d -f -g -j 32 -l -u -s
+        - ./testbin.sh

--- a/testbin.sh
+++ b/testbin.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+git clone https://github.com/pmmp/PocketMine-MP.git --recursive
+cd PocketMine-MP
+../bin/composer install
+./tests/travis.sh -p $(pwd)/../bin/php7/bin/php


### PR DESCRIPTION
This adds travis for compile.sh. I am unable to get it to concurrently execute all 4 builds, so one commit might take up to 50mins to check for travis.
It also tests the 4 bins with PocketMine and it's test suite.
A demonstration can be found here: https://travis-ci.org/robske110/php-build-scripts/builds/357797948