### PR TITLE
Detect number of CPU cores to pass to compile.sh

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -303,7 +303,16 @@ else
 		set -e
 		echo "[3/3] No prebuilt PHP found, compiling PHP automatically. This might take a while."
 		echo
-		exec "./compile.sh"
+		logical_cpu_count=$([ $(uname) = 'Darwin' ] && sysctl -n hw.logicalcpu_max ||  lscpu -p | egrep -v '^#' | wc -l) #Get available CPUs to pass to compile.sh and speed up compile
+		if [ $logical_cpu_count -gt 0 ];
+		then
+                        echo "Starting $logical_cpu_count thread compile"
+		        compile_command="./compile.sh -j $((logical_cpu_count))"
+                        exec $compile_command
+		else
+		        echo "Starting single thread compile"
+                        exec "./compile.sh"
+		fi
 	fi
 fi
 

--- a/installer.sh
+++ b/installer.sh
@@ -308,7 +308,7 @@ else
 		then
 			echo "Starting $logical_cpu_count thread compile"
 			compile_command="./compile.sh -j $((logical_cpu_count))"
-            exec $compile_command
+			exec $compile_command
 		else
 			echo "Starting single thread compile"
 			exec "./compile.sh"

--- a/installer.sh
+++ b/installer.sh
@@ -303,7 +303,7 @@ else
 		set -e
 		echo "[3/3] No prebuilt PHP found, compiling PHP automatically. This might take a while."
 		echo
-		logical_cpu_count=$([ $(uname) = 'Darwin' ] && sysctl -n hw.logicalcpu_max ||  lscpu -p | egrep -v '^#' | wc -l) #Get available CPUs to pass to compile.sh and speed up compile
+		logical_cpu_count=$([ $(uname) = 'Darwin' ] && sysctl -n hw.logicalcpu_max || lscpu -p | grep -e -v '^#' | wc -l) #Get available CPUs to pass to compile.sh and speed up compile
 		if [ $logical_cpu_count -gt 0 ];
 		then
                         echo "Starting $logical_cpu_count thread compile"

--- a/installer.sh
+++ b/installer.sh
@@ -64,7 +64,7 @@ if [ $? -eq 0 ]; then
 		alias download_file="wget -q -O -"
 	fi
 else
-	type curl >> /dev/null 2>&1
+	type a >> /dev/null 2>&1
 	if [ $? -eq 0 ]; then
 		if [ "$IGNORE_CERT" == "yes" ]; then
 			alias download_file="curl --insecure --silent --show-error --location --globoff"
@@ -303,15 +303,15 @@ else
 		set -e
 		echo "[3/3] No prebuilt PHP found, compiling PHP automatically. This might take a while."
 		echo
-		logical_cpu_count=$([ $(uname) = 'Darwin' ] && sysctl -n hw.logicalcpu_max || lscpu -p | grep -e -v '^#' | wc -l) #Get available CPUs to pass to compile.sh and speed up compile
+		logical_cpu_count=$([ $(uname) = 'Darwin' ] && sysctl -n hw.logicalcpu_max || nproc --all) #Get available CPUs to pass to compile.sh and speed up compile
 		if [ $logical_cpu_count -gt 0 ];
 		then
-                        echo "Starting $logical_cpu_count thread compile"
-		        compile_command="./compile.sh -j $((logical_cpu_count))"
-                        exec $compile_command
+			echo "Starting $logical_cpu_count thread compile"
+			compile_command="./compile.sh -j $((logical_cpu_count))"
+            exec $compile_command
 		else
-		        echo "Starting single thread compile"
-                        exec "./compile.sh"
+			echo "Starting single thread compile"
+			exec "./compile.sh"
 		fi
 	fi
 fi

--- a/installer.sh
+++ b/installer.sh
@@ -307,7 +307,7 @@ else
 		if [ $logical_cpu_count -gt 0 ];
 		then
 			echo "Starting $logical_cpu_count thread compile"
-			compile_command="./compile.sh -j $((logical_cpu_count))"
+			compile_command="./compile.sh -j $logical_cpu_count"
 			exec $compile_command
 		else
 			echo "Starting single thread compile"

--- a/installer.sh
+++ b/installer.sh
@@ -64,7 +64,7 @@ if [ $? -eq 0 ]; then
 		alias download_file="wget -q -O -"
 	fi
 else
-	type a >> /dev/null 2>&1
+	type curl >> /dev/null 2>&1
 	if [ $? -eq 0 ]; then
 		if [ "$IGNORE_CERT" == "yes" ]; then
 			alias download_file="curl --insecure --silent --show-error --location --globoff"
@@ -304,8 +304,7 @@ else
 		echo "[3/3] No prebuilt PHP found, compiling PHP automatically. This might take a while."
 		echo
 		logical_cpu_count=$([ "$(uname -s)" == "Darwin" ] && sysctl -n hw.logicalcpu_max || nproc --all) #Get available CPUs to pass to compile.sh and speed up compile
-		if [ $logical_cpu_count -gt 0 ];
-		then
+		if [ $logical_cpu_count -gt 0 ]; then
 			echo "Starting $logical_cpu_count thread compile"
 			compile_command="./compile.sh -j $logical_cpu_count"
 			exec $compile_command

--- a/installer.sh
+++ b/installer.sh
@@ -303,7 +303,7 @@ else
 		set -e
 		echo "[3/3] No prebuilt PHP found, compiling PHP automatically. This might take a while."
 		echo
-		logical_cpu_count=$([ $(uname) = 'Darwin' ] && sysctl -n hw.logicalcpu_max || nproc --all) #Get available CPUs to pass to compile.sh and speed up compile
+		logical_cpu_count=$([ "$(uname -s)" == "Darwin" ] && sysctl -n hw.logicalcpu_max || nproc --all) #Get available CPUs to pass to compile.sh and speed up compile
 		if [ $logical_cpu_count -gt 0 ];
 		then
 			echo "Starting $logical_cpu_count thread compile"


### PR DESCRIPTION
Speeds up compile time significantly. compile.sh is already ready for -j to be passed to it.
Using Darwin/Linux detection technique from https://stackoverflow.com/questions/18668556/how-can-i-compare-numbers-in-bash
Tested on Darwin Version 21.4.0 (Monterey), Ubuntu 18.04.6 LTS (Bionic Beaver), and Fedora 35 (Container Image)