### PR TITLE
fix #142, "sh syntax error when static build is enabled"

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -295,7 +295,7 @@ if [ "$DO_STATIC" == "yes" ]; then
 	if [ "$FSANITIZE_OPTIONS" != "" ]; then
 		echo "[warning] Sanitizers cannot be used on static builds"
 	fi
-	if [ "$HAVE_XDEBUG" == "yes"]; then
+	if [ "$HAVE_XDEBUG" == "yes" ]; then
 	  write_out "warning" "Xdebug cannot be built in static mode"
 	  HAVE_XDEBUG="no"
 	fi


### PR DESCRIPTION
fixed #142

```
./compile.sh  -t android-aarch64 -x -j4 -f
[PocketMine] PHP compiler for Linux, MacOS and Android
[INFO] Checking dependencies
[opt] Set target to android-aarch64
[opt] Doing cross-compile
[opt] Set make threads to 4
[opt] Enabling abusive optimizations...
[INFO] Cross-compiling for Android ARMv8 (aarch64)
[warning] OPcache cannot be used on static builds; this may have a negative effect on performance
[warning] Xdebug cannot be built in static mode
[PHP] downloading 8.0.22... done!
# ...
[PHP] enabling optimizations... checking... compiling... installing... generating php.ini... done!
[INFO] Cleaning up... done!
[PocketMine] You should start the server now using "./start.sh".
[PocketMine] If it doesn't work, please send the "install.log" file to the Bug Tracker.

```