### PR TITLE
README: Remove outdated -l option from examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Bash script used to compile PHP on MacOS and Linux platforms. Make sure you have
 
 | Target          | Arguments                        |
 | --------------- | -------------------------------- |
-| linux64         | ``-t linux64 -l -j4 -f x86_64``  |
-| mac64           | ``-t mac64 -l -j4 -f``           |
+| linux64         | ``-t linux64 -j4 -f x86_64``  |
+| mac64           | ``-t mac64 -j4 -f``           |
 | android-aarch64 | ``-t android-aarch64 -x -j4 -f`` |
 
 ### Common pitfalls


### PR DESCRIPTION
as the title says
The `-l` option has been removed by https://github.com/pmmp/php-build-scripts/commit/c3ec5975221854575cdb498422e6a2d09879a373
```
git log --oneline -n 1 -S "[opt] Will compile with LevelDB support" compile.sh
c3ec597 new extension chunkutils2
```
```
./compile.sh -t linux64 -l -j4 -f x86_64
# ...
Invalid option: -l
```