### PR TITLE
Use macos-13 to buid MacOS x86_64 PHP

### DIFF
--- a/.github/workflows/main-pm-matrix.yml
+++ b/.github/workflows/main-pm-matrix.yml
@@ -85,7 +85,7 @@ jobs:
         include:
           - target-name: mac-x86-64
             artifact-name: x86_64
-            image: macos-12
+            image: macos-14
           - target-name: mac-arm64
             artifact-name: arm64
             image: macos-14

--- a/.github/workflows/main-pm-matrix.yml
+++ b/.github/workflows/main-pm-matrix.yml
@@ -85,7 +85,7 @@ jobs:
         include:
           - target-name: mac-x86-64
             artifact-name: x86_64
-            image: macos-14
+            image: macos-14-large
           - target-name: mac-arm64
             artifact-name: arm64
             image: macos-14

--- a/.github/workflows/main-pm-matrix.yml
+++ b/.github/workflows/main-pm-matrix.yml
@@ -85,7 +85,7 @@ jobs:
         include:
           - target-name: mac-x86-64
             artifact-name: x86_64
-            image: macos-14-large
+            image: macos-13
           - target-name: mac-arm64
             artifact-name: arm64
             image: macos-14


### PR DESCRIPTION
The macOS-12 environment is deprecated. 
see https://github.com/actions/runner-images/issues/10721