### PR TITLE
Fixed variable assignment errors during Windows JIT compilation

### DIFF
--- a/windows-compile-vs.ps1
+++ b/windows-compile-vs.ps1
@@ -135,7 +135,7 @@ if ($PHP_DEBUG_BUILD -eq 0) {
 }
 
 if ($env:PHP_JIT_SUPPORT -eq 1) {
-    $PHP_JIT_ENABLE_ARG="on"
+    $PHP_JIT_ENABLE_ARG="yes"
     pm-echo "Compiling JIT support in OPcache (unstable)"
 }
 
@@ -610,7 +610,7 @@ append-file-utf8 "extension=php_recursionguard.dll" $php_ini
 append-file-utf8 "recursionguard.enabled=0 ;disabled due to minor performance impact, only enable this if you need it for debugging" $php_ini
 append-file-utf8 ";extension=php_arraydebug.dll" $php_ini
 append-file-utf8 "" $php_ini
-if ($PHP_JIT_ENABLE_ARG -eq "on") {
+if ($PHP_JIT_ENABLE_ARG -eq "yes") {
     append-file-utf8 "; ---- ! WARNING ! ----" $php_ini
     append-file-utf8 "; JIT can provide big performance improvements, but as of PHP %PHP_VER% it is still unstable. For this reason, it is disabled by default." $php_ini
     append-file-utf8 "; Enable it at your own risk. See https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.jit for possible options." $php_ini

--- a/windows-compile-vs.ps1
+++ b/windows-compile-vs.ps1
@@ -135,7 +135,7 @@ if ($PHP_DEBUG_BUILD -eq 0) {
 }
 
 if ($env:PHP_JIT_SUPPORT -eq 1) {
-    $PHP_JIT_ENABLE_ARG="yes"
+    $PHP_JIT_ENABLE_ARG="on"
     pm-echo "Compiling JIT support in OPcache (unstable)"
 }
 


### PR DESCRIPTION
$PHP_JIT_ENABLE-ARG should be assigned the value 'on' instead of 'yes' when jit is enabled