### PR TITLE
Fix pattern matching to check for Mac target

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1378,7 +1378,7 @@ if [ "$HAVE_OPCACHE" == "yes" ]; then
 		echo "opcache.jit_buffer_size=128M" >> "$INSTALL_DIR/bin/php.ini"
 	fi
 fi
-if [ "$COMPILE_TARGET" == "mac-"* ]; then
+if [[ "$COMPILE_TARGET" == "mac-"* ]]; then
 	#we don't have permission to allocate executable memory on macOS due to not being codesigned
 	#workaround this for now by disabling PCRE JIT
 	echo "" >> "$INSTALL_DIR/bin/php.ini"


### PR DESCRIPTION
In bash, `if [ ... ]` does not support pattern matching, so we have to use bash-specific double square brackets.

As an example, the following program will print `no match`:
```bash
#!/bin/bash

COMPILE_TARGET="mac-arm64"

if [ "$COMPILE_TARGET" == "mac-"* ]; then
	echo "match"
else
	echo "no match"
fi
```
But if we change it to `if [[ "$COMPILE_TARGET" == "mac-"* ]]` it works as expected.

I found this bug with the shellcheck program